### PR TITLE
Update aws sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
 dependencies {
     compile("io.dropwizard.metrics:metrics-core:3.1.0")
     compile("io.dropwizard.metrics:metrics-jvm:3.1.0")
-    compile("com.amazonaws:aws-java-sdk-cloudwatch:1.11.41")
+    compile("com.amazonaws:aws-java-sdk-cloudwatch:1.11.86")
     compile("com.google.guava:guava:19.0")
 
     compile("ch.qos.logback:logback-classic:1.1.7")


### PR DESCRIPTION
Just to keep the aws sdk up to date because I noticed some problems with outdated aws dependencies in the past... Sometimes even the patch version upgrades led to errors.