### PR TITLE
Bump dropwizard dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodaHale Aggregated Metrics CloudWatch Reporter
 
-This is a CloudWatch Reporter for the stable version of Dropwizard Metrics (formerly CodaHale & Yammer Metrics). The reporter is an implementation of [ScheduledReporter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/ScheduledReporter.html) from Dropwizard Metrics v3.2.3 
+This is a CloudWatch Reporter for the stable version of Dropwizard Metrics (formerly CodaHale & Yammer Metrics). The reporter is an implementation of [ScheduledReporter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/ScheduledReporter.html) from Dropwizard Metrics v4.0.1 
 
 ## Table of Contents
 
@@ -22,27 +22,27 @@ This is a CloudWatch Reporter for the stable version of Dropwizard Metrics (form
 ### Summary
 
 - This CloudWatchReporter reports the metric data to CloudWatch asynchronously using the [AmazonCloudWatchAsyncClient (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/AmazonCloudWatchAsyncClient.html) interface 
-- Each reportable value in CodeHale [Metric](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Metric.html) is reported as a separate [MetricDatum (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/MetricDatum.html) 
-- When reporting [Meter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Meter.html), [Counter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html) count metrics (`getCount()`) as [MetricDatum (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/MetricDatum.html), only the count difference since the last report is reported. This way the counters do not require a reset within the application using this reporter.
-- If configured, each [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html) translated into [StatisticSet (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/StatisticSet.html) in the most direct way possible.
+- Each reportable value in CodeHale [Metric](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Metric.html) is reported as a separate [MetricDatum (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/MetricDatum.html) 
+- When reporting [Meter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Meter.html), [Counter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html) count metrics (`getCount()`) as [MetricDatum (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/MetricDatum.html), only the count difference since the last report is reported. This way the counters do not require a reset within the application using this reporter.
+- If configured, each [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html) translated into [StatisticSet (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/StatisticSet.html) in the most direct way possible.
 - If configured, JVM statistic is reported
 
 ### Reportable Metrics
 
 Currently the only metric values that are reportable through configuration are:
 
-- Values of type `Number` from [Gauge](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Gauge.html)
-- Counts from [Counter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html), [Meter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Meter.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html)
-- Percentiles from [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html) in [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html)
-- Arithmetic mean & standard deviation of [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html) values in [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html)
-- Mean rates from [Meter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Meter.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html)
-- Summaries of [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html) values in [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html) as [StatisticSet (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/StatisticSet.html)
+- Values of type `Number` from [Gauge](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Gauge.html)
+- Counts from [Counter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html), [Meter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Meter.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html)
+- Percentiles from [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html) in [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html)
+- Arithmetic mean & standard deviation of [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html) values in [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html)
+- Mean rates from [Meter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Meter.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html)
+- Summaries of [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html) values in [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html) as [StatisticSet (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/StatisticSet.html)
 
 __Please note__:
 
-- [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) values (the `percentiles`, `min`, `max`, `sum`, `arithmetic mean` & `std-dev` from [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html)) are reported __raw__.
-- [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html) values (the `percentiles`, `min`, `max`, `sum`, `arithmetic mean` & `std-dev` from [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html)) are reported after conversion by a duration factor was applied. The duration factor is calculated by converting `1` unit of `duration unit` type to `nanoseconds` (see [ScheduledReporter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/ScheduledReporter.html))
-- [Meter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Meter.html) values (the `1min rate`, `5min rate`, `15min rate` & `mean rate`) are reported after conversion by a rate factor was applied. The rate factor is calculated by converting `1` unit of `rate unit` type to `seconds` (see [ScheduledReporter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/ScheduledReporter.html))
+- [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) values (the `percentiles`, `min`, `max`, `sum`, `arithmetic mean` & `std-dev` from [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html)) are reported __raw__.
+- [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html) values (the `percentiles`, `min`, `max`, `sum`, `arithmetic mean` & `std-dev` from [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html)) are reported after conversion by a duration factor was applied. The duration factor is calculated by converting `1` unit of `duration unit` type to `nanoseconds` (see [ScheduledReporter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/ScheduledReporter.html))
+- [Meter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Meter.html) values (the `1min rate`, `5min rate`, `15min rate` & `mean rate`) are reported after conversion by a rate factor was applied. The rate factor is calculated by converting `1` unit of `rate unit` type to `seconds` (see [ScheduledReporter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/ScheduledReporter.html))
 
 ### Defaults
 
@@ -67,8 +67,8 @@ The Reporter uses the following defaults which can be configured:
 
 The __only__ metrics that are reportable __by default__  are:
 
-- Count values (`getCount()`) from [Meter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Meter.html), [Counter](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html) 
-- Percentile values (`75%`, `95%`, `99.9%`) from [Histogram](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Timer.html)
+- Count values (`getCount()`) from [Meter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Meter.html), [Counter](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Counter.html), [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html) 
+- Percentile values (`75%`, `95%`, `99.9%`) from [Histogram](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Histogram.html) and [Timer](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Timer.html)
 
 All other metrics have to be confugured for reporting by invoking their respective `withXXXX()` methods on the `CloudWatchReporter.Builder` instance
 
@@ -90,8 +90,8 @@ dependencies {
 The library fetches the following transitive dependencies:
 
 ```
-    io.dropwizard.metrics:metrics-core:3.2.3
-    io.dropwizard.metrics:metrics-jvm:3.2.3
+    io.dropwizard.metrics:metrics-core:4.0.1
+    io.dropwizard.metrics:metrics-jvm:4.0.1
     com.amazonaws:aws-java-sdk-cloudwatch:1.11.179
     com.google.guava:guava:21.0
 ```
@@ -100,7 +100,7 @@ The library fetches the following transitive dependencies:
 
 ### Usage
 
-The reporter provides a fine-grained configuration options through its builder to configure what metrics should be reported to CloudWatch. Since AWS costs money, you probably do not want to report `all` the values from [Metric](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Metric.html) classes or [Snapshot](http://metrics.dropwizard.io/3.2.3/apidocs/com/codahale/metrics/Snapshot.html), but only what's really useful to you.
+The reporter provides a fine-grained configuration options through its builder to configure what metrics should be reported to CloudWatch. Since AWS costs money, you probably do not want to report `all` the values from [Metric](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Metric.html) classes or [Snapshot](http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/Snapshot.html), but only what's really useful to you.
 
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ allprojects {
 }
 
 dependencies {
-    compile("io.dropwizard.metrics:metrics-core:3.2.3")
-    compile("io.dropwizard.metrics:metrics-jvm:3.2.3")
+    compile("io.dropwizard.metrics:metrics-core:4.0.1")
+    compile("io.dropwizard.metrics:metrics-jvm:4.0.1")
     compile("com.amazonaws:aws-java-sdk-cloudwatch:1.11.179")
     compile("com.google.guava:guava:21.0")
 


### PR DESCRIPTION
We would like to use the latest dropwizard-metrics dependency. The tests indicate that nothing breaks.