### PR TITLE
replace guava with java8 native

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The library fetches the following transitive dependencies:
     io.dropwizard.metrics:metrics-core:4.0.0
     io.dropwizard.metrics:metrics-jvm:4.0.0
     com.amazonaws:aws-java-sdk-cloudwatch:1.11.179
-    com.google.guava:guava:21.0
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     compile("io.dropwizard.metrics:metrics-core:4.0.0")
     compile("io.dropwizard.metrics:metrics-jvm:4.0.0")
     compile("com.amazonaws:aws-java-sdk-cloudwatch:1.11.179")
-    compile("com.google.guava:guava:21.0")
 
     compile("ch.qos.logback:logback-classic:1.2.2")
     compile("org.slf4j:slf4j-api:1.7.25")


### PR DESCRIPTION
This change replaces guava with java native alternatives. The intent is to make this library a bit more portable for runtime environments that force old incompatible versions of guava (such as spark and hadoop). 

Some PR notes: there isn't a clear alternative to VisibleForTesting, but since the annotation isn't parsed anywhere I figured a comment was functionally equivalent. There isn't a great Iterables.partition built-in in java8 that preserves ordering, so I used a basic iterating subList approach that should be readable at a glance.

FWIW so far I've worked around the guava compatibility issue by relocating the guava packages, and it seems to work fine, but relocation is a bit clunky and removing guava was straight forward.