### PR TITLE
Remove logging backend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     compile("io.dropwizard.metrics:metrics-jvm:4.0.2")
     compile("com.amazonaws:aws-java-sdk-cloudwatch:1.11.179")
 
-    compile("ch.qos.logback:logback-classic:1.2.2")
     compile("org.slf4j:slf4j-api:1.7.25")
 
     testCompile("org.mockito:mockito-core:1.10.19")


### PR DESCRIPTION
Libraries should not necessarily provide slf4j implementations of their own. Let the application decide which logging backend to use