### PR TITLE
high resolution metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The Reporter uses the following defaults which can be configured:
 - Duration metrics are in `TimeUnit.Milliseconds`
 - `MetricFilter.ALL` will be used for the Filter
 - `Clock.defaultClock()` will be used for the Clock (Unconfigurable)
+- Metrics are reported using standard resolution (can be changed to [high resolution](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics))
 - Empty global [Dimension (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/Dimension.html) list
 - The reporter adds a `Type` [Dimension (AWS)](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudwatch/model/Dimension.html) to each reported metric, e.g:
 
@@ -131,6 +132,7 @@ The reporter provides a fine-grained configuration options through its builder t
                     .withGlobalDimensions("Region=us-west-2", "Instance=stage")
                     .withZeroValuesSubmission()
                     .withReportRawCountValue()
+                    .withHighResolution()
                     .withDryRun()
                     .build();
 

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
@@ -88,6 +88,26 @@ public class CloudWatchReporterTest {
     }
 
     @Test
+    public void notSettingHighResolutionGeneratesMetricsWithStorageResolutionSetToSixty() throws Exception {
+        metricRegistry.counter(ARBITRARY_COUNTER_NAME).inc();
+        reporterBuilder.build().report();
+
+        final MetricDatum firstMetricDatum = firstMetricDatumFromCapturedRequest();
+        
+        assertThat(firstMetricDatum.getStorageResolution()).isEqualTo(60);
+    }
+
+    @Test
+    public void settingHighResolutionGeneratesMetricsWithStorageResolutionSetToOne() throws Exception {
+        metricRegistry.counter(ARBITRARY_COUNTER_NAME).inc();
+        reporterBuilder.withHighResolution().build().report();
+
+        final MetricDatum firstMetricDatum = firstMetricDatumFromCapturedRequest();
+
+        assertThat(firstMetricDatum.getStorageResolution()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldReportWithoutGlobalDimensionsWhenGlobalDimensionsNotConfigured() throws Exception {
         metricRegistry.counter(ARBITRARY_COUNTER_NAME).inc();
         reporterBuilder.build().report(); // When 'withGlobalDimensions' was not called


### PR DESCRIPTION
Provides the possibility to report metrics to AWS using [high resolution](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics)