### PR TITLE
per metric dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ __Please note__:
 - [Timer](https://static.javadoc.io/io.dropwizard.metrics/metrics-core/4.0.2/com/codahale/metrics/Timer.html) values (the `percentiles`, `min`, `max`, `sum`, `arithmetic mean` & `std-dev` from [Snapshot](https://static.javadoc.io/io.dropwizard.metrics/metrics-core/4.0.2/com/codahale/metrics/Snapshot.html)) are reported after conversion by a duration factor was applied. The duration factor is calculated by converting `1` unit of `duration unit` type to `nanoseconds` (see [ScheduledReporter](https://static.javadoc.io/io.dropwizard.metrics/metrics-core/4.0.2/com/codahale/metrics/ScheduledReporter.html))
 - [Meter](https://static.javadoc.io/io.dropwizard.metrics/metrics-core/4.0.2/com/codahale/metrics/Meter.html) values (the `1min rate`, `5min rate`, `15min rate` & `mean rate`) are reported after conversion by a rate factor was applied. The rate factor is calculated by converting `1` unit of `rate unit` type to `seconds` (see [ScheduledReporter](https://static.javadoc.io/io.dropwizard.metrics/metrics-core/4.0.2/com/codahale/metrics/ScheduledReporter.html))
 
+### Metric Dimensions
+A dimension is a name/value pair that helps you to uniquely identify a metric. Every metric has specific characteristics that describe
+it, and you can think of dimensions as categories for those characteristics.
+
+#### Global Dimensions
+The reporter can be configured with a set of global dimensions. These will be added to all reported metrics.
+
+#### Per Metric Dimensions
+The reporter will look for dimensions encoded in the metric name when the metric is reported.
+To add dimensions to a metric, encode them inside square brackets at the end of the metric name;
+
+`"metricName[dimension1=value1,dimension2=value2]"`
+
+Use `DimensionedName` to more easily create metric names with dimensions;
+```java
+final DimensionedName dimensionedName = new DimensionedNameBuilder("counterName")
+            .addDimension(new Dimension().withName("key1").withValue("value1"))
+            .addDimension(new Dimension().withName("key2").withValue("value2"))
+            .build();
+
+metricRegistry.counter(dimensionedName.encode()).inc();
+````
+
 ### Defaults
 
 The Reporter uses the following defaults which can be configured:

--- a/README.md
+++ b/README.md
@@ -56,17 +56,39 @@ The reporter can be configured with a set of global dimensions. These will be ad
 The reporter will look for dimensions encoded in the metric name when the metric is reported.
 To add dimensions to a metric, encode them inside square brackets at the end of the metric name;
 
-`"metricName[dimension1=value1,dimension2=value2]"`
+`"metricName[dimension1:value1,dimension2:value2]"`
 
 Use `DimensionedName` to more easily create metric names with dimensions;
+
 ```java
-final DimensionedName dimensionedName = new DimensionedNameBuilder("counterName")
-            .addDimension(new Dimension().withName("key1").withValue("value1"))
-            .addDimension(new Dimension().withName("key2").withValue("value2"))
-            .build();
+final DimensionedName dimensionedName = DimensionedName.withName("test")
+        .withDimension("key1", "val1")
+        .withDimension("key2", "val2")
+        .withDimension("key3", "val3")
+        .build();
 
 metricRegistry.counter(dimensionedName.encode()).inc();
 ````
+
+It's also possible to derive a new `DimensionedName` from an existing one; 
+```java
+final DimensionedName dimensionedName = DimensionedName
+        .withName("test")
+        .withDimension("key1", "val1")
+        .withDimension("key2", "val2")
+        .withDimension("key3", "val3")
+        .build();
+
+final DimensionedName derivedDimensionedName = dimensionedName
+        .withDimension("key3", "replaced_value")
+        .withDimension("key4", "val4")
+        .build();
+
+metricRegistry.counter(dimensionedName.encode()).inc();
+metricRegistry.counter(derivedDimensionedName.encode()).inc();
+````
+
+Since `DimensionedName` is immutable, the string representation returned by `encode()` is cached. Multiple calls to `encode()` will return the same `String`. 
 
 ### Defaults
 

--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
@@ -27,6 +27,7 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import io.github.azagniotov.metrics.reporter.utils.CollectionsUtils;
+import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -340,13 +341,16 @@ public class CloudWatchReporter extends ScheduledReporter {
                                   final List<MetricDatum> metricData) {
         // Only submit metrics that show some data, so let's save some money
         if (metricConfigured && (builder.withZeroValuesSubmission || metricValue > 0)) {
+            final DimensionedName dimensionedName = DimensionedName.decode(metricName);
+
             final Set<Dimension> dimensions = new LinkedHashSet<>(builder.globalDimensions);
             dimensions.add(new Dimension().withName(DIMENSION_NAME_TYPE).withValue(dimensionValue));
+            dimensions.addAll(dimensionedName.getDimensions());
 
             metricData.add(new MetricDatum()
                     .withTimestamp(new Date(builder.clock.getTime()))
                     .withValue(cleanMetricValue(metricValue))
-                    .withMetricName(metricName)
+                    .withMetricName(dimensionedName.getName())
                     .withDimensions(dimensions)
                     .withStorageResolution(highResolution ? HIGH_RESOLUTION : STANDARD_RESOLUTION)
                     .withUnit(standardUnit));
@@ -359,6 +363,7 @@ public class CloudWatchReporter extends ScheduledReporter {
                                                        final StandardUnit standardUnit,
                                                        final List<MetricDatum> metricData) {
         if (metricConfigured) {
+            final DimensionedName dimensionedName = DimensionedName.decode(metricName);
             double scaledSum = convertDuration(LongStream.of(snapshot.getValues()).sum());
             final StatisticSet statisticSet = new StatisticSet()
                     .withSum(scaledSum)
@@ -368,12 +373,14 @@ public class CloudWatchReporter extends ScheduledReporter {
 
             final Set<Dimension> dimensions = new LinkedHashSet<>(builder.globalDimensions);
             dimensions.add(new Dimension().withName(DIMENSION_NAME_TYPE).withValue(DIMENSION_SNAPSHOT_SUMMARY));
+            dimensions.addAll(dimensionedName.getDimensions());
 
             metricData.add(new MetricDatum()
                     .withTimestamp(new Date(builder.clock.getTime()))
-                    .withMetricName(metricName)
+                    .withMetricName(dimensionedName.getName())
                     .withDimensions(dimensions)
                     .withStatisticValues(statisticSet)
+                    .withStorageResolution(highResolution ? HIGH_RESOLUTION : STANDARD_RESOLUTION)
                     .withUnit(standardUnit));
         }
     }
@@ -384,6 +391,7 @@ public class CloudWatchReporter extends ScheduledReporter {
                                                  final StandardUnit standardUnit,
                                                  final List<MetricDatum> metricData) {
         if (metricConfigured) {
+            final DimensionedName dimensionedName = DimensionedName.decode(metricName);
             double total = LongStream.of(snapshot.getValues()).sum();
             final StatisticSet statisticSet = new StatisticSet()
                     .withSum(total)
@@ -393,12 +401,14 @@ public class CloudWatchReporter extends ScheduledReporter {
 
             final Set<Dimension> dimensions = new LinkedHashSet<>(builder.globalDimensions);
             dimensions.add(new Dimension().withName(DIMENSION_NAME_TYPE).withValue(DIMENSION_SNAPSHOT_SUMMARY));
+            dimensions.addAll(dimensionedName.getDimensions());
 
             metricData.add(new MetricDatum()
                     .withTimestamp(new Date(builder.clock.getTime()))
-                    .withMetricName(metricName)
+                    .withMetricName(dimensionedName.getName())
                     .withDimensions(dimensions)
                     .withStatisticValues(statisticSet)
+                    .withStorageResolution(highResolution ? HIGH_RESOLUTION : STANDARD_RESOLUTION)
                     .withUnit(standardUnit));
         }
     }

--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
@@ -24,7 +24,7 @@ public class DimensionedName {
     if (matcher.find() && matcher.groupCount() == 2) {
       final DimensionedNameBuilder builder = new DimensionedNameBuilder(matcher.group(1).trim());
       for(String t : matcher.group(2).split(",")) {
-        final String[] keyAndValue = t.split("=");
+        final String[] keyAndValue = t.split(":");
         builder.addDimension(new Dimension()
             .withName(keyAndValue[0].trim())
             .withValue(keyAndValue[1].trim()));
@@ -49,7 +49,7 @@ public class DimensionedName {
         final StringBuilder sb = new StringBuilder(this.name);
         sb.append('[');
         sb.append(this.dimensions.stream()
-            .map(dimension -> dimension.getName() + "=" + dimension.getValue())
+            .map(dimension -> dimension.getName() + ":" + dimension.getValue())
             .collect(Collectors.joining(",")));
         sb.append(']');
 

--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
@@ -1,0 +1,68 @@
+package io.github.azagniotov.metrics.reporter.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import java.util.Collections;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class DimensionedName {
+  private static final Pattern dimensionPattern = Pattern.compile("([\\w.-]+)\\[([\\w\\W]+)]");
+  private final String name;
+  private final Set<Dimension> dimensions;
+
+  private String encoded;
+
+  DimensionedName(final String name, final Set<Dimension> dimensions) {
+    this.name = name;
+    this.dimensions = Collections.unmodifiableSet(dimensions);
+  }
+
+  public static DimensionedName decode(final String encodedDimensionedName) {
+    final Matcher matcher = dimensionPattern.matcher(encodedDimensionedName);
+    if (matcher.find() && matcher.groupCount() == 2) {
+      final DimensionedNameBuilder builder = new DimensionedNameBuilder(matcher.group(1).trim());
+      for(String t : matcher.group(2).split(",")) {
+        final String[] keyAndValue = t.split("=");
+        builder.addDimension(new Dimension()
+            .withName(keyAndValue[0].trim())
+            .withValue(keyAndValue[1].trim()));
+      }
+      return builder.build();
+    } else {
+      return new DimensionedNameBuilder(encodedDimensionedName).build();
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Set<Dimension> getDimensions() {
+    return dimensions;
+  }
+
+  public synchronized String encode() {
+    if (this.encoded == null) {
+      if (!dimensions.isEmpty()) {
+        final StringBuilder sb = new StringBuilder(this.name);
+        sb.append('[');
+        sb.append(this.dimensions.stream()
+            .map(dimension -> dimension.getName() + "=" + dimension.getValue())
+            .collect(Collectors.joining(",")));
+        sb.append(']');
+
+        this.encoded = sb.toString();
+      } else {
+        this.encoded = this.name;
+      }
+    }
+    return this.encoded;
+  }
+
+  @Override
+  public String toString() {
+    return this.encode();
+  }
+}

--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameBuilder.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameBuilder.java
@@ -1,0 +1,24 @@
+package io.github.azagniotov.metrics.reporter.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import java.util.HashSet;
+import java.util.Set;
+
+public class DimensionedNameBuilder {
+  private final String name;
+  private Set<Dimension> dimensions = new HashSet<>();
+
+  public DimensionedNameBuilder(final String name) {
+    this.name = name;
+  }
+
+
+  public DimensionedNameBuilder addDimension(final Dimension dimension) {
+    this.dimensions.add(dimension);
+    return this;
+  }
+
+  public DimensionedName build() {
+    return new DimensionedName(this.name, this.dimensions);
+  }
+}

--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameBuilder.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameBuilder.java
@@ -1,24 +1,28 @@
 package io.github.azagniotov.metrics.reporter.cloudwatch;
 
 import com.amazonaws.services.cloudwatch.model.Dimension;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DimensionedNameBuilder {
   private final String name;
-  private Set<Dimension> dimensions = new HashSet<>();
+  private Map<String, Dimension> dimensions;
 
-  public DimensionedNameBuilder(final String name) {
-    this.name = name;
+  DimensionedNameBuilder(final String name) {
+    this(name, new HashMap<>());
   }
 
-
-  public DimensionedNameBuilder addDimension(final Dimension dimension) {
-    this.dimensions.add(dimension);
-    return this;
+  DimensionedNameBuilder(final String name, final Map<String, Dimension> dimensions) {
+    this.name = name;
+    this.dimensions = dimensions;
   }
 
   public DimensionedName build() {
     return new DimensionedName(this.name, this.dimensions);
+  }
+
+  public DimensionedNameBuilder withDimension(final String name, final String value) {
+    this.dimensions.put(name, new Dimension().withName(name).withValue(value));
+    return this;
   }
 }

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
@@ -280,9 +280,11 @@ public class CloudWatchReporterTest {
 
     @Test
     public void shouldReportExpectedGlobalAndCustomDimensions() throws Exception {
-        metricRegistry.counter(new DimensionedNameBuilder(ARBITRARY_COUNTER_NAME)
-            .addDimension(new Dimension().withName("key1").withValue("value1"))
-            .addDimension(new Dimension().withName("key2").withValue("value2"))
+
+
+        metricRegistry.counter(DimensionedName.withName(ARBITRARY_COUNTER_NAME)
+            .withDimension("key1", "value1")
+            .withDimension("key2", "value2")
             .build().encode()).inc();
         reporterBuilder.withGlobalDimensions("Region=us-west-2").build().report();
 

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
@@ -279,6 +279,21 @@ public class CloudWatchReporterTest {
     }
 
     @Test
+    public void shouldReportExpectedGlobalAndCustomDimensions() throws Exception {
+        metricRegistry.counter(new DimensionedNameBuilder(ARBITRARY_COUNTER_NAME)
+            .addDimension(new Dimension().withName("key1").withValue("value1"))
+            .addDimension(new Dimension().withName("key2").withValue("value2"))
+            .build().encode()).inc();
+        reporterBuilder.withGlobalDimensions("Region=us-west-2").build().report();
+
+        final List<Dimension> dimensions = firstMetricDatumDimensionsFromCapturedRequest();
+
+        assertThat(dimensions).contains(new Dimension().withName("Region").withValue("us-west-2"));
+        assertThat(dimensions).contains(new Dimension().withName("key1").withValue("value1"));
+        assertThat(dimensions).contains(new Dimension().withName("key2").withValue("value2"));
+    }
+
+    @Test
     public void shouldReportExpectedMultipleGlobalDimensions() throws Exception {
         metricRegistry.counter(ARBITRARY_COUNTER_NAME).inc();
         reporterBuilder.withGlobalDimensions("Region=us-west-2", "Instance=stage").build().report();

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
@@ -23,13 +23,30 @@ public class DimensionedNameTest {
   }
 
   @Test
-  public void canEncodeDimensionedNameToStering() {
-    final DimensionedName dimensionedName = new DimensionedNameBuilder("test")
-        .addDimension(new Dimension().withName("key1").withValue("val1"))
-        .addDimension(new Dimension().withName("key2").withValue("val2"))
-        .addDimension(new Dimension().withName("key3").withValue("val3"))
+  public void canEncodeDimensionedNameToString() {
+    final DimensionedName dimensionedName = DimensionedName.withName("test")
+        .withDimension("key1", "val1")
+        .withDimension("key2", "val2")
+        .withDimension("key3", "val3")
         .build();
 
     assertEquals("test[key1:val1,key2:val2,key3:val3]", dimensionedName.encode());
+  }
+
+  @Test
+  public void canDeriveDimensionedNameFromCurrent() {
+    final DimensionedName dimensionedName = DimensionedName.withName("test")
+        .withDimension("key1", "val1")
+        .withDimension("key2", "val2")
+        .withDimension("key3", "val3")
+        .build();
+
+
+    final DimensionedName derivedDimensionedName = dimensionedName
+        .withDimension("key3", "new_value")
+        .withDimension("key4", "val4").build();
+
+    assertEquals("test[key1:val1,key2:val2,key3:val3]", dimensionedName.encode());
+    assertEquals("test[key1:val1,key2:val2,key3:new_value,key4:val4]", derivedDimensionedName.encode());
   }
 }

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
@@ -1,0 +1,35 @@
+package io.github.azagniotov.metrics.reporter.cloudwatch;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.*;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import org.junit.Test;
+
+public class DimensionedNameTest {
+  @Test
+  public void canDecodeDimensionedString() {
+    final String dimensioned = "test[key1=val1,key2=val2,key3=val3]";
+
+    final DimensionedName dimensionedName = DimensionedName.decode(dimensioned);
+
+    assertEquals("test", dimensionedName.getName());
+    assertEquals(3, dimensionedName.getDimensions().size());
+
+    assertThat(dimensionedName.getDimensions(), hasItems(
+        new Dimension().withName("key1").withValue("val1"),
+        new Dimension().withName("key2").withValue("val2"),
+        new Dimension().withName("key3").withValue("val3")));
+  }
+
+  @Test
+  public void canEncodeDimensionedNameToStering() {
+    final DimensionedName dimensionedName = new DimensionedNameBuilder("test")
+        .addDimension(new Dimension().withName("key1").withValue("val1"))
+        .addDimension(new Dimension().withName("key2").withValue("val2"))
+        .addDimension(new Dimension().withName("key3").withValue("val3"))
+        .build();
+
+    assertEquals("test[key1=val1,key2=val2,key3=val3]", dimensionedName.encode());
+  }
+}

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedNameTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class DimensionedNameTest {
   @Test
   public void canDecodeDimensionedString() {
-    final String dimensioned = "test[key1=val1,key2=val2,key3=val3]";
+    final String dimensioned = "test[key1:val1,key2:val2,key3:val3]";
 
     final DimensionedName dimensionedName = DimensionedName.decode(dimensioned);
 
@@ -30,6 +30,6 @@ public class DimensionedNameTest {
         .addDimension(new Dimension().withName("key3").withValue("val3"))
         .build();
 
-    assertEquals("test[key1=val1,key2=val2,key3=val3]", dimensionedName.encode());
+    assertEquals("test[key1:val1,key2:val2,key3:val3]", dimensionedName.encode());
   }
 }


### PR DESCRIPTION
This PR makes it possible to provide dimensions per metric. Typically by doing something like this;

```java
final DimensionedName dimensionedName = DimensionedName.withName("test")
        .withDimension("key1", "val1")
        .withDimension("key2", "val2")
        .withDimension("key3", "val3")
        .build();

metricRegistry.counter(dimensionedName.encode()).inc();
````

Sadly AWS doesn't support aggregating custom metrics on dimensions (yet?), so the usefulness is more or less limited to improved search and filtering in the *CloudWatch* console for now...

Related to: https://github.com/azagniotov/codahale-aggregated-metrics-cloudwatch-reporter/issues/19