### PR TITLE
Dependency upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ buildscript {
     }
 }
 
+plugins {
+  id "com.github.ben-manes.versions" version "0.27.0"
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.8
@@ -30,16 +34,16 @@ allprojects {
 }
 
 dependencies {
-    compile("io.dropwizard.metrics:metrics-core:4.0.2")
-    compile("io.dropwizard.metrics:metrics-jvm:4.0.2")
-    compile("software.amazon.awssdk:cloudwatch:2.10.13")
-    compile("org.slf4j:slf4j-api:1.7.25")
+    compile("io.dropwizard.metrics:metrics-core:4.0.7")
+    compile("io.dropwizard.metrics:metrics-jvm:4.0.7")
+    compile("software.amazon.awssdk:cloudwatch:2.10.16")
+    compile("org.slf4j:slf4j-api:1.7.29")
 
-    testCompile("org.mockito:mockito-core:1.10.19")
+    testCompile("org.mockito:mockito-core:3.1.0")
     testCompile("junit:junit:4.12")
-    testCompile("com.google.truth:truth:0.32")
-    testCompile("org.hamcrest:hamcrest-core:1.3")
-    testCompile("org.hamcrest:hamcrest-library:1.3")
+    testCompile("com.google.truth:truth:1.0")
+    testCompile("org.hamcrest:hamcrest-core:2.2")
+    testCompile("org.hamcrest:hamcrest-library:2.2")
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
- Add gradle plugin for dependency updates
- Run `gradle dependencyUpdates` and update libraries as much as possible without `gradle build` breaking. There are pending upgrades to metrics libraries
- There exist some deprecation warnings with upgrade of mockito-core, let me know if they need fixing