### PR TITLE
Dependency upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ allprojects {
 dependencies {
     compile("io.dropwizard.metrics:metrics-core:4.0.7")
     compile("io.dropwizard.metrics:metrics-jvm:4.0.7")
-    compile("software.amazon.awssdk:cloudwatch:2.10.16")
+    compile("software.amazon.awssdk:cloudwatch:2.10.31")
     compile("org.slf4j:slf4j-api:1.7.29")
 
-    testCompile("org.mockito:mockito-core:3.1.0")
+    testCompile("org.mockito:mockito-core:3.2.0")
     testCompile("junit:junit:4.12")
     testCompile("com.google.truth:truth:1.0")
     testCompile("org.hamcrest:hamcrest-core:2.2")


### PR DESCRIPTION
Upgrading sdkv2 (which has enhancements and fixes to aws core sdk and netty) and mockito, this doesn't mandate a new release