### PR TITLE
Update cloudwatch to 2.10.56

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 dependencies {
     compile("io.dropwizard.metrics:metrics-core:4.0.7")
     compile("io.dropwizard.metrics:metrics-jvm:4.0.7")
-    compile("software.amazon.awssdk:cloudwatch:2.10.55")
+    compile("software.amazon.awssdk:cloudwatch:2.10.56")
     compile("org.slf4j:slf4j-api:1.7.29")
 
     testCompile("org.mockito:mockito-core:3.2.4")


### PR DESCRIPTION
@azagniotov this has an important netty fix for long running clients https://github.com/aws/aws-sdk-java-v2/pull/1611 and aws has issued an advisory to run this minimum version. Please review and if possible make a release