### PR TITLE
Allow percentiles to be removed

### DIFF
--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
@@ -727,9 +727,7 @@ public class CloudWatchReporter extends ScheduledReporter {
          * @return {@code this}
          */
         public Builder withPercentiles(final Percentile... percentiles) {
-            if (percentiles.length > 0) {
-                this.percentiles = percentiles;
-            }
+            this.percentiles = percentiles;
             return this;
         }
 


### PR DESCRIPTION
I'm using a meter because I'd quite like to retrieve percentiles locally, but I'm only really interested in the count on prod as cloudwatch can derive them. This pr removes the check for percentiles so I can remove them.