### PR TITLE
only invoke Gauge.getValue once per report

### DIFF
--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporter.java
@@ -212,10 +212,10 @@ public class CloudWatchReporter extends ScheduledReporter {
     }
 
     private void processGauge(final String metricName, final Gauge gauge, final List<MetricDatum> metricData) {
-        if (gauge.getValue() instanceof Number) {
-            final Number number = (Number) gauge.getValue();
-            stageMetricDatum(true, metricName, number.doubleValue(), StandardUnit.NONE, DIMENSION_GAUGE, metricData);
-        }
+        Optional.ofNullable(gauge.getValue())
+            .filter(value -> value instanceof Number)
+            .map(value -> (Number) value)
+            .ifPresent(value -> stageMetricDatum(true, metricName, value.doubleValue(), StandardUnit.NONE, DIMENSION_GAUGE, metricData));
     }
 
     private void processCounter(final String metricName, final Counting counter, final List<MetricDatum> metricData) {

--- a/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
+++ b/src/test/java/io/github/azagniotov/metrics/reporter/cloudwatch/CloudWatchReporterTest.java
@@ -40,6 +40,7 @@ import static io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporte
 import static io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter.DIMENSION_SNAPSHOT_SUMMARY;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -125,6 +126,20 @@ public class CloudWatchReporterTest {
         final List<Dimension> dimensions = firstMetricDatumDimensionsFromCapturedRequest();
 
         assertThat(dimensions).contains(Dimension.builder().name(DIMENSION_NAME_TYPE).value(DIMENSION_COUNT).build());
+    }
+
+    @Test
+    public void reportedGaugesAreInvokedOnlyOnce() {
+        Gauge<Long> theGauge = spy(new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                return 1L;
+            }
+        });
+        metricRegistry.register(ARBITRARY_GAUGE_NAME, theGauge);
+        reporterBuilder.build().report();
+
+        verify(theGauge).getValue();
     }
 
     @Test


### PR DESCRIPTION
`Gauge.getValue` might be an expensive operation and should therefor not be invoked more than **once** per report occasion.