### PR TITLE
Align metric name regex with AWS naming requirements

### DIFF
--- a/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
+++ b/src/main/java/io/github/azagniotov/metrics/reporter/cloudwatch/DimensionedName.java
@@ -13,7 +13,13 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class DimensionedName {
-    private static final Pattern dimensionPattern = Pattern.compile("([\\w.-]+)\\[([\\w\\W]+)]");
+    private static final String cgAllowed = "[\\p{ASCII}&&[^:,]]";
+    private static final String cgNonWsAllowed = "[" + cgAllowed + "&&[\\S]]";
+    static final String pToken = cgAllowed + "*" + cgNonWsAllowed + "+" + cgAllowed + "*";
+    private static final String pKeyValue = pToken + ":" + pToken;
+    private static final String pDimensions = "\\[((?:" + pKeyValue + "(?:," + pKeyValue + ")*)?)\\]";
+    static final String pNamespace = "\\s*([\\w.\\-/#:]+)\\s*";
+    static final Pattern dimensionPattern = Pattern.compile("^" + pNamespace + pDimensions + "$");
     private final String name;
     private final Map<String, Dimension> dimensions;
 


### PR DESCRIPTION
This PR aligns the regular expression that is used to analyze dimensional metric names with AWS's requirements for these names.

The rules for namespaces are (cf. [cloudwatch_concepts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)): alphanumeric characters (0-9A-Za-z), period (.), hyphen (-), underscore (_), forward slash (/), hash (#), and colon (:).

The rules for dimension names and values are (cf. [API_Dimension](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html)):

Dimension names must contain only ASCII characters, must include at least one non-whitespace character, and cannot start with a colon (:).

Dimension values must contain only ASCII characters and must include at least one non-whitespace character.


